### PR TITLE
Update `xbyak` submodule to the latest commit

### DIFF
--- a/include/kthook/x86_64/kthook_x86_64_detail.hpp
+++ b/include/kthook/x86_64/kthook_x86_64_detail.hpp
@@ -834,7 +834,7 @@ inline bool unfreeze_threads(frozen_threads& threads) {
 
 inline struct JumpAllocator : Xbyak::Allocator {
     uint8_t* alloc(size_t size) override {
-        void* ptr = Xbyak::AlignedMalloc(size, Xbyak::inner::ALIGN_PAGE_SIZE);
+        void* ptr = Xbyak::AlignedMalloc(size, Xbyak::inner::getPageSize());
         set_memory_prot(ptr, size, MemoryProt::PROTECT_RWE);
         return reinterpret_cast<uint8_t*>(ptr);
     }
@@ -847,7 +847,7 @@ inline struct JumpAllocator : Xbyak::Allocator {
 
 inline struct TrampolineAllocator : Xbyak::Allocator {
     uint8_t* alloc(size_t size) override {
-        void* ptr = Xbyak::AlignedMalloc(size, Xbyak::inner::ALIGN_PAGE_SIZE);
+        void* ptr = Xbyak::AlignedMalloc(size, Xbyak::inner::getPageSize());
         set_memory_prot(ptr, size, MemoryProt::PROTECT_RWE);
         return reinterpret_cast<uint8_t*>(ptr);
     }


### PR DESCRIPTION
CMake v4.0.0 was recently released, and using the current `xbyak` library breaks the build of a project that uses the current version of CMake, with the next error message:

```bash
CMake Error at build/_deps/kthook-src/xbyak/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

You can add flag that suggested to suppress this error message, but I think it would be better to update the module, which is what this pull request does.