### PR TITLE
Replace deprecated std::is_trivial in C++26

### DIFF
--- a/include/kthook/x64/kthook_detail.hpp
+++ b/include/kthook/x64/kthook_detail.hpp
@@ -22,7 +22,12 @@ constexpr relay_args_info internal_get_head_and_tail_size(std::size_t integral_r
     bool used = false;
     if constexpr (!std::is_void_v<Ret>) {
         auto res =
+#if (defined(__cplusplus) && __cplusplus > 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG > 202302L)
+            (!(std::is_trivially_copyable_v<Ret> && std::is_trivially_default_constructible_v<Ret>
+               && std::is_standard_layout_v<Ret> && (sizeof(Ret) % 2 == 0 || sizeof(Ret) == 1) && sizeof(Ret) <= 8));
+#else
             (!(std::is_trivial_v<Ret> && std::is_standard_layout_v<Ret> && (sizeof(Ret) % 2 == 0 || sizeof(Ret) == 1) && sizeof(Ret) <= 8));
+#endif
         if (res) used = true;
         used_integral_registers += res;
     }

--- a/include/kthook/x86/kthook_detail.hpp
+++ b/include/kthook/x86/kthook_detail.hpp
@@ -142,7 +142,12 @@ template <typename Ret>
 constexpr bool is_return_value_needs_stack() {
     if constexpr (std::is_void_v<Ret>) return false;
 
+#if (defined(__cplusplus) && __cplusplus > 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG > 202302L)
+    return (!(std::is_trivially_copyable_v<Ret> && std::is_trivially_default_constructible_v<Ret>
+              && std::is_standard_layout_v<Ret> && sizeof(Ret) <= 8));
+#else
     return (!(std::is_trivial_v<Ret> && std::is_standard_layout_v<Ret> && sizeof(Ret) <= 8));
+#endif
 }
 
 template <typename HookPtrType, traits::cconv Convention, typename Ret, typename... Args>

--- a/include/kthook/x86/kthook_detail.hpp
+++ b/include/kthook/x86/kthook_detail.hpp
@@ -156,7 +156,6 @@ struct signal_relay_generator;
 template <typename HookPtrType, typename Ret, typename... Args>
 struct signal_relay_generator<HookPtrType, traits::cconv::ccdecl, Ret, std::tuple<Args...>> {
     static Ret CCDECL relay(HookPtrType* this_hook, Args ... args) {
-        using source_t = Ret(CCDECL*)(Args ...);
         return signal_relay<HookPtrType, Ret, Args...>(this_hook, args...);
     }
 }; // namespace detail
@@ -164,7 +163,6 @@ struct signal_relay_generator<HookPtrType, traits::cconv::ccdecl, Ret, std::tupl
 template <typename HookPtrType, typename Ret, typename... Args>
 struct signal_relay_generator<HookPtrType, traits::cconv::cstdcall, Ret, std::tuple<Args...>> {
     static Ret CSTDCALL relay(HookPtrType* this_hook, Args ... args) {
-        using source_t = Ret(CSTDCALL*)(Args ...);
         return signal_relay<HookPtrType, Ret, Args...>(this_hook, args...);
     }
 };

--- a/include/kthook/x86/kthook_impl.hpp
+++ b/include/kthook/x86/kthook_impl.hpp
@@ -363,7 +363,12 @@ private:
 #ifdef _WIN32
         jump_gen->pop(eax);
         if constexpr (!std::is_void_v<Ret>) {
+#if (defined(__cplusplus) && __cplusplus > 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG > 202302L)
+            constexpr bool is_fully_nontrivial = !(std::is_trivially_copyable_v<Ret> && std::is_trivially_default_constructible_v<Ret>)
+                                                 || !std::is_trivially_destructible_v<Ret>;
+#else
             constexpr bool is_fully_nontrivial = !std::is_trivial_v<Ret> || !std::is_trivially_destructible_v<Ret>;
+#endif
             if constexpr (sizeof(Ret) > 8 || is_fully_nontrivial) {
                 if constexpr ((is_thiscall || is_fastcall) && (sizeof(Ret) % 2 != 0 || is_fully_nontrivial)) {
                     jump_gen->push(reinterpret_cast<std::uintptr_t>(this));
@@ -396,7 +401,12 @@ private:
         // if Ret is class or union, memory for return value as first argument(hidden)
         // so we need to push our hook pointer after this hidden argument
         if constexpr (!std::is_void_v<Ret>) {
+#if (defined(__cplusplus) && __cplusplus > 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG > 202302L)
+            constexpr bool is_fully_nontrivial = !(std::is_trivially_copyable_v<Ret> && std::is_trivially_default_constructible_v<Ret>)
+                                                 || !std::is_trivially_destructible_v<Ret>;
+#else
             constexpr bool is_fully_nontrivial = !std::is_trivial_v<Ret> || !std::is_trivially_destructible_v<Ret>;
+#endif
             if constexpr (std::is_class_v<Ret> || std::is_union_v<Ret> || sizeof(Ret) > 8) {
                 if constexpr (is_thiscall && (sizeof(Ret) % 2 != 0 || is_fully_nontrivial)) {
                     jump_gen->push(reinterpret_cast<std::uintptr_t>(this));
@@ -657,7 +667,12 @@ private:
 #ifdef _WIN32
         jump_gen->pop(eax);
         if constexpr (!std::is_void_v<Ret>) {
+#if (defined(__cplusplus) && __cplusplus > 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG > 202302L)
+            constexpr bool is_fully_nontrivial = !(std::is_trivially_copyable_v<Ret> && std::is_trivially_default_constructible_v<Ret>)
+                                                 || !std::is_trivially_destructible_v<Ret>;
+#else
             constexpr bool is_fully_nontrivial = !std::is_trivial_v<Ret> || !std::is_trivially_destructible_v<Ret>;
+#endif
             if constexpr (sizeof(Ret) > 8 || is_fully_nontrivial) {
                 if constexpr ((is_thiscall || is_fastcall) && (sizeof(Ret) % 2 != 0 || is_fully_nontrivial)) {
                     jump_gen->push(reinterpret_cast<std::uintptr_t>(this));

--- a/include/kthook/x86/kthook_impl.hpp
+++ b/include/kthook/x86/kthook_impl.hpp
@@ -85,7 +85,6 @@ inline bool create_trampoline(std::uintptr_t hook_address,
     };
 
     std::size_t trampoline_size = 0;
-    std::size_t op_copy_size = 0;
     void* op_copy_src = nullptr;
     std::uintptr_t current_address = hook_address;
     std::uintptr_t max_jmp_ref = 0;

--- a/include/kthook/x86_64/kthook_x86_64_detail.hpp
+++ b/include/kthook/x86_64/kthook_x86_64_detail.hpp
@@ -839,7 +839,7 @@ inline struct JumpAllocator : Xbyak::Allocator {
         return reinterpret_cast<uint8_t*>(ptr);
     }
 
-    void free(uint8_t* p) override {
+    void free(uint8_t*) override {
     }
 
     bool useProtect() const override { return false; }

--- a/include/kthook/x86_64/kthook_x86_64_detail.hpp
+++ b/include/kthook/x86_64/kthook_x86_64_detail.hpp
@@ -416,7 +416,7 @@ constexpr decltype(auto) unpack_impl(Output& output) {
 }
 
 template <typename Input, typename Output, std::size_t... Is>
-constexpr decltype(auto) unpack(Output output, std::index_sequence<Is...>) {
+constexpr decltype(auto) unpack([[maybe_unused]] Output output, std::index_sequence<Is...>) {
     return std::tuple_cat(unpack_impl<Input, Is>(output)...);
 }
 


### PR DESCRIPTION
`std::is_trivial` is deprecated in C++26 ([P3247: Deprecate the notion of trivial types](https://wg21.link/p3247)). GCC 15.1.1 with `-std=c++26` will generate a warning.

Using `std::is_trivially_copyable && std::is_trivially_default_constructible` checks for `Ret` to replace `std::is_trivial`.